### PR TITLE
Added resetPosition() to reposition clickover

### DIFF
--- a/js/bootstrapx-clickover.js
+++ b/js/bootstrapx-clickover.js
@@ -122,6 +122,47 @@
     , isShown: function() {
       return this.tip().hasClass('in');
     }
+    , resetPosition: function() {
+        var $tip
+        , inside
+        , pos
+        , actualWidth
+        , actualHeight
+        , placement
+        , tp
+
+      if (this.hasContent() && this.enabled) {
+        $tip = this.tip()
+
+        placement = typeof this.options.placement == 'function' ?
+          this.options.placement.call(this, $tip[0], this.$element[0]) :
+          this.options.placement
+
+        inside = /in/.test(placement)
+
+        pos = this.getPosition(inside)
+
+        actualWidth = $tip[0].offsetWidth
+        actualHeight = $tip[0].offsetHeight
+
+        switch (inside ? placement.split(' ')[1] : placement) {
+          case 'bottom':
+            tp = {top: pos.top + pos.height, left: pos.left + pos.width / 2 - actualWidth / 2}
+            break
+          case 'top':
+            tp = {top: pos.top - actualHeight, left: pos.left + pos.width / 2 - actualWidth / 2}
+            break
+          case 'left':
+            tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth}
+            break
+          case 'right':
+            tp = {top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width}
+            break
+        }
+
+        $tip.css(tp)
+      }
+    }
     , debughide: function() {
       var dt = new Date().toString();
 


### PR DESCRIPTION
Needed this in one of my projects when retrieving clickover content via an ajax request.

While the clickover div grows, the positioning does not get updated. This function allows a simple call to resetPosition() to update the position of a clickover based on the content within it. It is based on the original positioning code found in bootstrap.

This is particularly more suitable to bootstrapx-clickover since we can use onShown events to easily fire ajax events on open (unlike the current bootstrap popover)
