### PR TITLE
Add namespace to clickevent

### DIFF
--- a/js/bootstrapx-clickover.js
+++ b/js/bootstrapx-clickover.js
@@ -39,7 +39,7 @@
       this.init( type, element, options );
 
       // setup our own handlers
-      this.$element.on( 'click', this.options.selector, $.proxy(this.clickery, this) );
+      this.$element.on( 'click.' + this.type, this.options.selector, $.proxy(this.clickery, this) );
 
       // soon add click hanlder to body to close this element
       // will need custom handler inside here


### PR DESCRIPTION
Currently the click eventhandler is added without an namespace, therefore destroy() doesn't work because bootstrap popover removes the events with this.type as namespace

   destroy: function () {
      this.hide().$element.off('.' + this.type).removeData(this.type)
    }
