### PR TITLE
Fix clickover reopening when closing it by tapping the toggle button

### DIFF
--- a/js/bootstrapx-clickover.js
+++ b/js/bootstrapx-clickover.js
@@ -39,7 +39,7 @@
       this.init( type, element, options );
 
       // setup our own handlers
-      this.$element.on( 'click', this.options.selector, $.proxy(this.clickery, this) );
+      this.$element.on( 'click touchstart', this.options.selector, $.proxy(this.clickery, this) );
 
       // soon add click hanlder to body to close this element
       // will need custom handler inside here


### PR DESCRIPTION
On mobile, when you have the clickover opened and you want to close it by tapping the clickover toggle button the clickover immediately opens again after closing. Adding `touchstart` to the event listener applied to the button fixes this issue.
